### PR TITLE
Add pre- and post-event forms to repo

### DIFF
--- a/docs/forms.md
+++ b/docs/forms.md
@@ -3,9 +3,9 @@
 For now, these forms are not taking public responses to make sure we don't get information before we are ready. They all need to be made public pre-event.
 
 ## 1.1 Speaker event
-- [Pre-event attendee sign up]()
+- [Pre-event attendee sign up](https://docs.google.com/forms/d/e/1FAIpQLSf0IgPYgf0di8eM6HP1qbqduPTeGEFadXZRSIDYEXlEOgA_bw/viewform?usp=sf_link). This may be better as a meetup event to collect the info as a group and advertise, but for now we have a form.
 - [Post-event feedback form](https://docs.google.com/forms/d/e/1FAIpQLSe7oMTwfLZfntqh9p8Npfsd9-o4jhSaVjhMNuuVMen8RmG3Ow/viewform?usp=sf_link)
 
 ## 1.2 Sprint
-- [Pre-event attendee sign up]()
+- [Pre-event attendee sign up]
 - [Post-event feedback form](https://docs.google.com/forms/d/e/1FAIpQLScaMDzERRMprL1TBQcKGjv9SZ8hFCFfA-keCXWDKfJf5v20Jw/viewform?usp=sf_link)

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -1,0 +1,11 @@
+# Forms related to the events
+
+For now, these forms are not taking public responses to make sure we don't get information before we are ready. They all need to be made public pre-event.
+
+## 1.1 Speaker event
+- [Pre-event attendee sign up]()
+- [Post-event feedback form](https://docs.google.com/forms/d/e/1FAIpQLSe7oMTwfLZfntqh9p8Npfsd9-o4jhSaVjhMNuuVMen8RmG3Ow/viewform?usp=sf_link)
+
+## 1.2 Sprint
+- [Pre-event attendee sign up]()
+- [Post-event feedback form](https://docs.google.com/forms/d/e/1FAIpQLScaMDzERRMprL1TBQcKGjv9SZ8hFCFfA-keCXWDKfJf5v20Jw/viewform?usp=sf_link)

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -7,5 +7,5 @@ For now, these forms are not taking public responses to make sure we don't get i
 - [Post-event feedback form](https://docs.google.com/forms/d/e/1FAIpQLSe7oMTwfLZfntqh9p8Npfsd9-o4jhSaVjhMNuuVMen8RmG3Ow/viewform?usp=sf_link)
 
 ## 1.2 Sprint
-- [Pre-event attendee sign up]
+- [Pre-event attendee sign up](https://docs.google.com/forms/d/e/1FAIpQLSfyB3NAbNcYLIQX8ODI5m86R4hnt0T5z2HP-rNLMUmbRciyZg/viewform?usp=sf_link)
 - [Post-event feedback form](https://docs.google.com/forms/d/e/1FAIpQLScaMDzERRMprL1TBQcKGjv9SZ8hFCFfA-keCXWDKfJf5v20Jw/viewform?usp=sf_link)


### PR DESCRIPTION
- [x] Check if there is any specific information needed in the attendee forms to be passed on to get people their invites
- [x] Write speaker event attendee forms
- [x] Write speaker event feedback forms
- [x] Write sprint event attendee forms
- [x] Write sprint event feedback forms

The non-checked options are currently empty links. 

Please note
> For now, these forms are not taking public responses to make sure we don't get information before we are ready. They all need to be made public pre-event.