### PR TITLE
Update CoC with additional event details

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -22,6 +22,29 @@ This includes:
 - Official event communications 
 - Event interactions on GitHub whether through issues, pull requests, comments, review, or related interactions
 
+## Inappropriate behavior
+
+Examples of unacceptable behavior by participants include:
+
+- Harassment of any participants in any form
+- Deliberate intimidation, stalking, or following
+- Logging or taking screenshots of online activity for harassment purposes
+- Publishing others’ private information, such as a physical or electronic address, without explicit permission
+- Violent threats or language directed against another person
+- Incitement of violence or harassment towards any individual, including encouraging a person to commit suicide or to engage in self-harm
+- Creating additional online accounts in order to harass another person or circumvent a ban
+- Sexual language and imagery in online communities or in any conference venue, including talks
+- Insults, put downs, or jokes that are based upon stereotypes, that are exclusionary, or that hold others up for ridicule
+- Excessive swearing
+- Unwelcome sexual attention or advances
+- Unwelcome physical contact, including simulated physical contact (eg, textual descriptions like “hug” or “backrub) without consent or after a request to stop
+- Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
+- Sustained disruption of online community discussions, in-person presentations, or other in-person events
+- Continued one-on-one communication after requests to cease
+- Other conduct that is inappropriate for a professional audience including people of many different backgrounds
+
+Community members asked to stop any inappropriate behavior are expected to comply immediately.
+
 ## During-event consequences
 
 If a participant engages in behavior that violates this Code of Conduct, they are subject to the consequences listed in the Project Jupyter Code of Conduct.

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -2,7 +2,7 @@
 
 Jupyter accessibility workshops are events within the Project Jupyter community. They follow [Project Jupyter's Code of Conduct](https://jupyter.org/conduct/).
 
-Project Jupyter's Code of Conduct mentions that events may have additional specifications to ensure that people are kept safe in real-time interactions. For Jupyter accessibility workshops, we would like to specify the following:
+As per Project Jupyter's Code of Conduct - events may have additional specifications to ensure that people are kept safe in real-time interactions. For Jupyter accessibility workshops, we the following addendums to the Code of Conduct have been made and will be enforced
 
 ## Scope and event spaces
 
@@ -13,6 +13,7 @@ This Code of Conduct applies to the following people in Jupyter accessibility wo
 - maintainers
 - reviewers
 - contributors
+- speakers
 
 Jupyter accessibility workshops are online events that gather across multiple platforms. The Code of Conduct applies to any online space where we interact for the events, whether meeting in real time or asynchorously pre- and post-event. Event organizers will enforce this code throughout the event.
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,2 +1,4 @@
 Jupyter accessibility workshops are events within the Project Jupyter community.
 They follow [Project Jupyter's Code of Conduct](https://jupyter.org/conduct/).
+
+Project Jupyter's Code of Conduct mentions that events may have additional specifications to ensure that people are kept safe in real-time interactions. For Jupyter accessibility workshops, we would like to specify the following:

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -40,7 +40,8 @@ If you believe someone has violated the Code of Conduct, we encourage you to rep
 
 Whether for immediate or post-event actions, you may report Code of Conduct violations to at least one of the following event moderators:
 - Isabela Presedo-Floyd
-- [needs at least two]
+- Tania Allard
+- [ask for other Jupyter community members]
 
 As soon as possible, the incident and action will be reported as a Project Jupyter Code of Conduct violation following the process listed [here](https://jupyter.org/conduct/).
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -62,8 +62,8 @@ If you believe someone is in physical danger, including from themselves, the mos
 If you believe someone has violated the Code of Conduct, we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
 
 Whether for immediate or post-event actions, you may report Code of Conduct violations to at least one of the following event moderators:
-- Isabela Presedo-Floyd
-- Tania Allard
+- Isabela Presedo-Floyd (ipresedo@quansight.com)
+- Tania Allard (tallard@quansight.com)
 - [ask for other Jupyter community members]
 
 As soon as possible, the incident and action will be reported as a Project Jupyter Code of Conduct violation following the process listed [here](https://jupyter.org/conduct/).

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,4 +1,55 @@
-Jupyter accessibility workshops are events within the Project Jupyter community.
-They follow [Project Jupyter's Code of Conduct](https://jupyter.org/conduct/).
+# Jupyter Accessibility Workshops Code of Conduct
+
+Jupyter accessibility workshops are events within the Project Jupyter community. They follow [Project Jupyter's Code of Conduct](https://jupyter.org/conduct/).
 
 Project Jupyter's Code of Conduct mentions that events may have additional specifications to ensure that people are kept safe in real-time interactions. For Jupyter accessibility workshops, we would like to specify the following:
+
+## Scope and event spaces
+
+This Code of Conduct applies to the following people in Jupyter accessibility workshop online spaces:
+- admins of the online space
+- all event attendees
+- all community members
+- maintainers
+- reviewers
+- contributors
+
+Jupyter accessibility workshops are online events that gather across multiple platforms. The Code of Conduct applies to any online space where we interact for the events, whether meeting in real time or asynchorously pre- and post-event. Event organizers will enforce this code throughout the event.
+
+This includes:
+- Event video and text chats
+- Official event communications 
+- Event interactions on GitHub whether through issues, pull requests, comments, review, or related interactions
+
+## During-event consequences
+
+If a participant engages in behavior that violates this Code of Conduct, they are subject to the consequences listed in the Project Jupyter Code of Conduct.
+
+To create a safe environment during the event, immediate action on Code of Conduct violations may be needed. Immediate actions may include the following:
+- Warning by event moderators
+- Banning from the event chat
+- Removal from breakout/discussion rooms
+- Removal from the event
+
+### Procedure For Reporting Incidents
+
+If you believe someone is in physical danger, including from themselves, the most important thing is to get that person help. Please contact the appropriate crisis number, non-emergency number, or police number. You can consult with a moderator to help find an appropriate number.
+
+If you believe someone has violated the Code of Conduct, we encourage you to report it. If you are unsure whether the incident is a violation, or whether the space where it happened is covered by the Code of Conduct, we encourage you to still report it. We are fine with receiving reports where we decide to take no action for the sake of creating a safer space.
+
+Whether for immediate or post-event actions, you may report Code of Conduct violations to at least one of the following event moderators:
+- Isabela Presedo-Floyd
+- [needs at least two]
+
+As soon as possible, the incident and action will be reported as a Project Jupyter Code of Conduct violation following the process listed [here](https://jupyter.org/conduct/).
+
+For violations that do not require immediate action, you may report directly following the process listed at the [Project Jupyter Code of Conduct](https://jupyter.org/conduct/).
+
+## Code of conduct license
+
+All sections of the Code of Conduct created specifically for the event are licensed under the [Creative Commons Attribution-ShareAlike 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/).
+
+## References
+[PyCon US 2021](https://us.pycon.org/2021/about/code-of-conduct/) which in turn draws from many Code of Conduct resources. 
+
+Thank you for helping make this a welcoming, friendly community for everyone.


### PR DESCRIPTION
Project Jupyter's Code of Conduct—the base CoC for these events— mentions that events may have additional specifications to ensure that people are kept safe in real-time interactions. We'd like to add some specifics (like behavior in chat and what removal from an online event would be like) to make sure our event is safe and clear in expectations.

References:
[PyCon US 2021 Code of Conduct](https://us.pycon.org/2021/about/code-of-conduct/)
