### PR TITLE
Update readme with January event details

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,28 @@
 Where Jupyter accessibility events are dreamed up, planned, and happening.
 
 ## Upcoming events 
-to be determined
+
+[Jupyter community workshops](https://blog.jupyter.org/jupyter-community-workshops-cbd34ac82549) for accessibility are coming to a virtual space near you in 2022!
+
+These events are open to the public. No prior accessibility knowledge is needed, and newcomers are welcome. Visit each event's agenda for more information.
+
+### Part 1: January 2022
+
+January 15: Jupyter Accessibility Workshops with [Frank Elvasky](https://chartability.fizz.studio/): How to build inclusive data representations
+
+- [Event agenda](https://github.com/Quansight-Labs/jupyter-accessibility-workshops/blob/main/events/2022-january-15/group_agenda.md)
+- [Sign up](https://docs.google.com/forms/d/e/1FAIpQLSf0IgPYgf0di8eM6HP1qbqduPTeGEFadXZRSIDYEXlEOgA_bw/viewform?usp=sf_link)
+
+January 22: Jupyter Accessibility Workshops: Writing image descriptions for documentation
+
+- [Event agenda](https://github.com/Quansight-Labs/jupyter-accessibility-workshops/blob/main/events/2022-january-22/mentored_sprint_agenda.md)
+- [Sign up](https://docs.google.com/forms/d/e/1FAIpQLSfyB3NAbNcYLIQX8ODI5m86R4hnt0T5z2HP-rNLMUmbRciyZg/viewform?usp=sf_link)
+
+### Part 2: March 2022 
+
+Details to be announced after January events!
+
 ___
+
 Please visit [jupyter/accessibility](https://github.com/jupyter/accessibility) 
 for more general acccessibility efforts in the Jupyter ecosystem.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # jupyter-accessibility-workshops
 Where Jupyter accessibility events are dreamed up, planned, and happening.
+## Next event: **January 15** - Jupyter Accessibility Workshops with [Frank Elvasky](https://chartability.fizz.studio/): How to build inclusive data representations ([in your timezone]()).
 
 ## Upcoming events 
 


### PR DESCRIPTION
Just what it says in the title. The read me is a great place to give a brief overview of upcoming events and link to other resources.

This PR:
- Adds titles, agenda links, and sign up links for January 15 and January 22 events
- Mentions March events

At some point I need to add a link for timezones, but I haven't put that on anything yet so it's not here yet either.

Let me know if you think there's anything else missing. 🌻 