### PR TITLE
Create Moderator Handbook

### DIFF
--- a/docs/moderator-handbook.md
+++ b/docs/moderator-handbook.md
@@ -1,0 +1,57 @@
+# Jupyter Accessibility Workshop Moderator Handbook!
+
+Hooray! If you are here, you might help moderate one of the upcoming (virtual) Jupyter accessibility workshops. The rest of the organizing team is grateful for your time and care in helping us maintain a welcoming community.
+
+You can find more information about the events on the [Jupyter accessibility workshop GitHub repo](https://github.com/Quansight-Labs/jupyter-accessibility-workshops).
+
+The events will be hosted on [Hopin](https://hopin.com/), which runs on [StreamYard](https://streamyard.com/). You won't need to handle all of these platforms; this is just to let you know where other organizing staff might be in case you need to find them at the event.
+
+## What is a moderator?
+
+
+
+## What can moderators do?
+
+Moderators are responsible for helping event organizers, especially those with admin permissions, maintain an experience that follows the [event code of conduct](https://github.com/Quansight-Labs/jupyter-accessibility-workshops/blob/main/code-of-conduct.md). In most cases, this includes:
+- Monitoring event chat, video, and audio streams
+- Being present in one breakout room
+- Contacting event organizers in the case of tech issues that can't be resolved
+- Warning participants of Code of Conduct violations if they do not warrant immediate action
+- Contacting event organizers to take removal actions against Code of Conduct violations
+- Taking note of Code of Conduct violations so that they may be reported as a full [Jupyter Code of Conduct violation report]()
+
+For these events, moderators do not have admin permissions. They need to reach out to an admin to take action beyond a warning.
+
+While helping moderate, moderators are free to enjoy the event!
+
+### Warning participants
+
+In most cases, at least one warning should be given to a participant before taking further action.
+
+Cases where action needs to be taken immediately, without warning, are as follows:
+- If a participant threatens another person at the event
+- If a participant is a threat to themselves
+
+Even in cases where a warning occurs, please take note of the violation for further Jupyter Code of Conduct reporting.
+
+### Banning participants from the event chat
+
+This may be chat in main session or session room, depending where the paricipant is.
+
+Banning participants from the event chat is the first action to be taken after a warning if the behavior is happening via chat. 
+
+To ban a participant from chat
+1. Warn participant
+2. If behavior persists, contact admin via ___ and ask the participant to be removed from chat.
+
+You may also consider taking a screen shot of the behavior if applicable for the full [Jupyter Code of Conduct violation report]().
+
+### Removing comments from the event chat
+
+### Removing participants from breakout/discussion rooms
+
+### Removing participants from the event
+
+## What resources do moderators have?
+
+## Where can I ask more questions?


### PR DESCRIPTION
Moderating events is important, and Code of Conducts aren't written for moderators alone. This work-in-progress document is meant to help moderators feel clear on their responsibilities and abilities for these events.

This is a draft, but I'm not making a draft PR so that it can be reviewed as desired.

Thanks in advance for any review! 🌻 